### PR TITLE
Potential fix for code scanning alert no. 209: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/plugins/server/server-installpanel.js
+++ b/plugins/server/server-installpanel.js
@@ -32,8 +32,14 @@ handler.mods = true
 export default handler
 
 function generatePassword(length = 4) {
-const chars = "0123456789"
-return Array.from(crypto.randomBytes(length))
-.map(byte => chars[byte % chars.length])
-.join("")
+    const chars = "0123456789";
+    const charsLen = chars.length;
+    let password = "";
+    while (password.length < length) {
+        const byte = crypto.randomBytes(1)[0];
+        // Only accept bytes less than (256 - 256 % charsLen) to avoid modulo bias
+        if (byte >= Math.floor(256 / charsLen) * charsLen) continue;
+        password += chars[byte % charsLen];
+    }
+    return password;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/209](https://github.com/naruyaizumi/liora/security/code-scanning/209)

To fix this, we should avoid directly applying the modulo operator to cryptographically secure random bytes, as it introduces bias. The best fix is to use a rejection sampling technique: after generating a random byte, if the value is greater than or equal to the largest multiple of the character set length that is still less than 256 (i.e., discard bytes >= 250 for a character set length of 10), we discard that byte and generate a new one. This ensures each character is chosen with uniform probability.

Changes should be made only within the `generatePassword` function in `plugins/server/server-installpanel.js`. No new packages are needed; `crypto` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
