### PR TITLE
Potential fix for code scanning alert no. 212: Unnecessary use of `cat` process

### DIFF
--- a/plugins/info/info-ping.js
+++ b/plugins/info/info-ping.js
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process'
 import os from 'os'
+import fs from 'fs'
 
 function formatSize(bytes) {
 if (!bytes || isNaN(bytes)) return '0 B'
@@ -55,7 +56,7 @@ return { model, cores }
 
 function getRAMInfo() {
 try {
-let meminfo = execSync('cat /proc/meminfo').toString().split('\n').reduce((acc, line) => {
+let meminfo = fs.readFileSync('/proc/meminfo').toString().split('\n').reduce((acc, line) => {
 let [key, value] = line.split(':')
 if (key && value) acc[key.trim()] = parseInt(value.trim())
 return acc


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/212](https://github.com/naruyaizumi/liora/security/code-scanning/212)

To fix the problem, replace the use of `execSync('cat /proc/meminfo')` with `fs.readFileSync('/proc/meminfo')`, which reads the contents of the file directly and avoids spawning an external process. This change should be made in the function `getRAMInfo` within plugins/info/info-ping.js. The `fs` module must be imported at the top of the file if it isn't already. The rest of the code that splits and parses the contents can remain unchanged. No other functionality will be affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
