### PR TITLE
Potential fix for code scanning alert no. 211: Unnecessary use of `cat` process

### DIFF
--- a/plugins/info/info-ping.js
+++ b/plugins/info/info-ping.js
@@ -35,7 +35,7 @@ return { botUptime, vpsUptime }
 
 function getOSPrettyName() {
 try {
-let lines = execSync('cat /etc/os-release').toString().split('\n')
+let lines = fs.readFileSync('/etc/os-release').toString().split('\n')
 let info = lines.reduce((acc, line) => {
 let [key, val] = line.split('=')
 if (key && val) acc[key.trim()] = val.replace(/"/g, '')


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/211](https://github.com/naruyaizumi/liora/security/code-scanning/211)

To fix the problem, we should replace the use of `execSync('cat /etc/os-release')` with `fs.readFileSync('/etc/os-release')`, leveraging the built-in Node.js file system module, which is already imported. This change should be applied in the `getOSPrettyName` function in the file `plugins/info/info-ping.js`, specifically on line 38. The rest of the code in the function can remain unchanged, as `fs.readFileSync` returns a buffer that can be converted to string in the same way. No new imports or dependencies are necessary, as `fs` is already imported at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
