### PR TITLE
Potential fix for code scanning alert no. 214: Incomplete URL substring sanitization

### DIFF
--- a/plugins/downloader/downloader-xvideosdl.js
+++ b/plugins/downloader/downloader-xvideosdl.js
@@ -1,7 +1,14 @@
 let handler = async (m, { conn, args, usedPrefix, command }) => {
 if (!args[0]) return m.reply(`🍔 *Masukkan link video Xvideos untuk diunduh!*\n\n🍱 *Contoh: ${usedPrefix + command} https://www.xvideos.com/...*\n\n⚠️ *WARNING: This feature contains 18+ NSFW content*`)
 let url = args[0]
-if (!url.includes("xvideos.com")) return m.reply("🍟 *Link tidak valid!*")
+let hostname
+try {
+    hostname = new URL(url).hostname
+} catch {
+    return m.reply("🍟 *Link tidak valid!*")
+}
+// Only allow xvideos.com or its subdomains
+if (!(hostname === "xvideos.com" || hostname.endsWith(".xvideos.com"))) return m.reply("🍟 *Link tidak valid!*")
 await global.loading(m, conn)
 try {
 let apiUrl = global.API("btz", "/api/download/xvideosdl", { url }, "apikey")


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/214](https://github.com/naruyaizumi/liora/security/code-scanning/214)

The best way to fix this substring check is to use Node.js URL parsing to extract the `hostname` from the user-provided URL and then strictly check if it matches `xvideos.com` or a valid subdomain of `xvideos.com` (i.e., it ends with `.xvideos.com`). For this single code snippet, do the following:
- Replace the substring check `!url.includes("xvideos.com")` with a check on the `hostname` after safely parsing the URL.
- Use the built-in `URL` class (`require('url')` not needed in modern Node.js) to parse `url`.
- Accept the URL if the hostname is `xvideos.com` or, optionally, any subdomain (e.g. `en.xvideos.com`) by verifying that the hostname either is `"xvideos.com"` or ends with `".xvideos.com"`.
- Add error-handling for invalid URLs that cannot be parsed.
Adjust only the block performing this validation/check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
