### PR TITLE
Potential fix for code scanning alert no. 213: Incomplete URL substring sanitization

### DIFF
--- a/plugins/downloader/downloader-xnxxdl.js
+++ b/plugins/downloader/downloader-xnxxdl.js
@@ -1,6 +1,13 @@
 let handler = async (m, { conn, args, usedPrefix, command }) => {
 if (!args[0]) return m.reply(`🍱 *Please provide a valid XNXX video link!*\n\n🍜 *Example:*\n${usedPrefix + command} https://www.xnxx.com/video-xxxx`)
-if (!args[0].includes("xnxx.com")) return m.reply("🍟 *Invalid link! Please enter a valid XNXX link.*")
+let allowedHosts = [ "xnxx.com", "www.xnxx.com" ];
+let host;
+try {
+  host = (new URL(args[0])).hostname;
+} catch {
+  return m.reply("🍟 *Invalid link! Please enter a valid XNXX link.*");
+}
+if (!allowedHosts.includes(host)) return m.reply("🍟 *Invalid link! Please enter a valid XNXX link.*");
 await global.loading(m, conn)
 try {
 // TODO: API is still under maintenance, replace logic below once it's fixed


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/213](https://github.com/naruyaizumi/liora/security/code-scanning/213)

To properly validate the input as a genuine xnxx.com URL, we should parse the incoming URL using a standard library (`url` or the built-in `URL` global in Node.js/modern JavaScript) and check that the `hostname` property is either "xnxx.com" or a valid subdomain like "www.xnxx.com". Replace the substring check with a structured host whitelist comparison. If necessary, normalize the hostname for comparison and consider only exact allowed hostnames (or provide a regex if broader validation is desired). Only respond with success if the parsed hostname matches the expected value.

Make changes in `plugins/downloader/downloader-xnxxdl.js`:  
- Add a robust hostname check on line 3, parsing the URL with the `URL` class.
- Add a definition for allowed hosts.
- Remove the substring check.

If `URL` is not available in the project context, use the built-in alternative (e.g., `require('url').parse`, but modern JS should support `URL`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
