### PR TITLE
Potential fix for code scanning alert no. 243: Shell command built from environment values

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1,4 +1,4 @@
-import { execSync } from "child_process"
+import { execSync, execFileSync } from "child_process"
 import process from "process"
 import chalk from "chalk"
 import fs from "fs"
@@ -62,7 +62,12 @@ async function doUpdate() {
   const extracted = dirs.find(d => d.toLowerCase().startsWith("liora-"))
   if (!extracted) throw new Error("Extracted folder not found")
   const skip = ["config.js", ".env", "database.json", "engine-requirements.js", "auth"]
-  execSync(`rsync -av --progress tmp/${extracted}/ ./ --exclude ${skip.join(" --exclude ")}`, { stdio: "inherit" })
+  const rsyncArgs = [
+    "-av", "--progress",
+    `tmp/${extracted}/`, "./",
+    ...skip.map(s => ["--exclude", s]).flat()
+  ]
+  execFileSync("rsync", rsyncArgs, { stdio: "inherit" })
   execSync("rm -rf tmp node_modules", { stdio: "inherit" })
   installDeps()
 }


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/243](https://github.com/naruyaizumi/liora/security/code-scanning/243)

The best way to fix this issue is to avoid constructing shell commands by interpolating untrusted directory names directly into strings. Instead, use `execFileSync`, which takes command and arguments separately (thus arguments are properly escaped and do not get interpreted by the shell). For the `rsync` command, split the command into its components: the executable (`rsync`), the static options, the dynamic paths and excludes as separate arguments.  
Specifically, on line 65 of `lib/core.js`, replace the `execSync` interpolation with a corresponding `execFileSync` call, passing all args as individual array elements. You'll need to flatten the skip/excludes array accordingly.

- Change: Replace line 65 with a call to `execFileSync("rsync", argsArray, { stdio: "inherit" })`.
- Add import of `execFileSync` (from `"child_process"`).
- Change `extracted` and `skip`-related logic into args array logic.

Only the region shown in `lib/core.js` should be changed.  
No other places need fixing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
