### PR TITLE
Potential fix for code scanning alert no. 240: Useless conditional

### DIFF
--- a/plugins/group/group-simulate.js
+++ b/plugins/group/group-simulate.js
@@ -43,12 +43,11 @@ let handler = async (m, { conn, usedPrefix, command, args: [event], text }) => {
                 m
             );
     }
-    if (act)
-        return conn.participantsUpdate({
-            id: m.chat,
-            participants: part,
-            action: act,
-        });
+    return conn.participantsUpdate({
+        id: m.chat,
+        participants: part,
+        action: act,
+    });
 };
 
 handler.help = ["simulate"];


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/240](https://github.com/naruyaizumi/liora/security/code-scanning/240)

To fix the problem, remove the useless conditional `if (act)` at line 46 and unconditionally invoke the `conn.participantsUpdate` function. This should be done within the same code snippet, ensuring that no functionality is changed, since all executions reaching this point have a valid `act` value.

No imports or auxiliary definitions are needed. Just change the lines:

```js
46:     if (act)
47:         return conn.participantsUpdate({
48:             id: m.chat,
49:             participants: part,
50:             action: act,
51:         });
```
to

```js
46:     return conn.participantsUpdate({
47:         id: m.chat,
48:         participants: part,
49:         action: act,
50:     });
```

All other logic is untouched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
