### PR TITLE
Potential fix for code scanning alert no. 233: Useless assignment to local variable

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -105,7 +105,7 @@ function bind(conn) {
             chats.presences = presence;
             if (id.endsWith("@g.us")) {
                 let groupChats = conn.chats[id];
-                if (!groupChats) groupChats = conn.chats[id] = { id };
+                if (!groupChats) conn.chats[id] = { id };
             }
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/233](https://github.com/naruyaizumi/liora/security/code-scanning/233)

To fix the problem, we should remove the unnecessary assignment to `groupChats`, leaving only the assignment to `conn.chats[id]`. On line 108, change `groupChats = conn.chats[id] = { id };` to `conn.chats[id] = { id };`. This edit ensures the function retains its logic while eliminating the useless local assignment. Since the code does not subsequently use the local variable, no further changes are necessary.

Only code within lines 107–109 is affected, and no new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
