### PR TITLE
Potential fix for code scanning alert no. 239: Duplicate character in character class

### DIFF
--- a/plugins/tool/tool-calc.js
+++ b/plugins/tool/tool-calc.js
@@ -12,7 +12,7 @@ let handler = async (m, { text, usedPrefix, command }) => {
             .replace(/%/g, "/100")
             .replace(/π|pi/gi, "Math.PI")
             .replace(/\be\b/gi, "Math.E");
-        if (!/^[0-9+\-*/().\sMathPIE*]+$/.test(expr)) {
+        if (!/^[0-9+\-*/().\sMathPIE]+$/.test(expr)) {
             return m.reply(
                 `🍩 *Ekspresi mengandung karakter ilegal!*\n\n*Coba contoh valid:*\n*${usedPrefix + command} (10+5)%*`
             );


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/239](https://github.com/naruyaizumi/liora/security/code-scanning/239)

To fix the problem, remove the redundant asterisk `*` from the character class in the regular expression on line 15. The character class should contain only one instance of each character meant to be matched. This can be done by editing the regex on line 15 in plugins/tool/tool-calc.js: replace `/^[0-9+\-*/().\sMathPIE*]+$/` with `/^[0-9+\-*/().\sMathPIE]+$/`, leaving all other logic unchanged. No imports or other code changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
