### PR TITLE
Potential fix for code scanning alert no. 235: Superfluous trailing arguments

### DIFF
--- a/plugins/maker/maker-sticker.js
+++ b/plugins/maker/maker-sticker.js
@@ -37,8 +37,7 @@ let handler = async (m, { conn, args, usedPrefix, command }) => {
                 false,
                 args[0],
                 global.config.stickpack,
-                global.config.stickauth,
-                20
+                global.config.stickauth
             );
             await conn.sendFile(m.chat, stiker, "sticker.webp", "", m);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/235](https://github.com/naruyaizumi/liora/security/code-scanning/235)

To fix this problem, the extra superfluous argument (`20`) passed to the `sticker` function call should be removed, leaving only the parameters that the `sticker` function actually uses. This guarantees that only the necessary arguments are passed, improving code clarity and maintainability. The edit should be made precisely on the call to `sticker` in the conditional block for URLs, i.e., in lines 36–42 of `plugins/maker/maker-sticker.js`.

No imports or other edits are required elsewhere unless this argument is used in variables defined above. Since the function definition for `sticker` is not being edited (and is not shown), only the callsite needs to be fixed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
