### PR TITLE
Potential fix for code scanning alert no. 234: Useless assignment to local variable

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -208,7 +208,7 @@ async function deletePanelUser(userId) {
         }
         let serversToDelete = [];
         let currentPage = 1;
-        let totalPages = 1;
+        let totalPages;
         do {
             const response = await fetch(`${domain}/api/application/servers?page=${currentPage}`, {
                 method: "GET",


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/234](https://github.com/naruyaizumi/liora/security/code-scanning/234)

To fix the problem, we should remove the unnecessary initial value assignment `= 1` from `let totalPages = 1;` on line 211. Instead, declare `totalPages` without an initializer: `let totalPages;`. This does not change existing functionality but eliminates the redundant assignment. This edit should be performed in `lib/server.js` at line 211, within the `deletePanelUser` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
