### PR TITLE
Potential fix for code scanning alert no. 389: Missing regular expression anchor

### DIFF
--- a/plugins/downloader/downloader-ig.js
+++ b/plugins/downloader/downloader-ig.js
@@ -8,7 +8,7 @@ let handler = async (m, { conn, usedPrefix, command, args }) => {
     );
   }
   const url = args[0].trim();
-  if (/instagram\.com\/stories\//i.test(url)) {
+  if (/^https?:\/\/(www\.)?instagram\.com\/stories\//i.test(url)) {
     return m.reply("Instagram Story URLs are not supported.");
   }
   if (!/^https?:\/\/(www\.)?instagram\.com\//i.test(url)) {


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/389](https://github.com/naruyaizumi/liora/security/code-scanning/389)

To fix the problem, add anchors (`^`) at the beginning of the regular expression on line 11 so that it matches only Instagram Story URLs that appear at the beginning of the URL string. This prevents accidental matches on URLs that merely contain "instagram.com/stories/" as a substring in a non-Instagram domain. Specifically, replace:
```js
if (/instagram\.com\/stories\//i.test(url)) {
```
with:
```js
if (/^https?:\/\/(www\.)?instagram\.com\/stories\//i.test(url)) {
```
No other changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
