### PR TITLE
Potential fix for code scanning alert no. 362: Useless assignment to local variable

### DIFF
--- a/plugins/tool/tool-compress.js
+++ b/plugins/tool/tool-compress.js
@@ -40,7 +40,7 @@ let handler = async (m, { conn, usedPrefix, command, args }) => {
         if (sizeKB < 200) quality += 5;
         quality = Math.max(20, Math.min(95, quality));
 
-        let outFormat = format;
+        let outFormat;
         const pipe = sharp(input, { failOn: "none" });
 
         if (format === "jpeg" || format === "jpg") {


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/362](https://github.com/naruyaizumi/liora/security/code-scanning/362)

To fix the problem, simply remove the initial assignment `let outFormat = format;` on line 43. Instead, declare `let outFormat;`, and rely on the later unambiguous assignments to `outFormat` within the image format branches. This preserves full functionality and reduces unnecessary code.

- File to edit: `plugins/tool/tool-compress.js`
- Region: Line 43 (`let outFormat = format;`)
- Change: Replace `let outFormat = format;` with `let outFormat;`
- No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
