### PR TITLE
Potential fix for code scanning alert no. 361: Useless assignment to local variable

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -40,7 +40,7 @@ function drawImageCover(ctx, img, x, y, w, h) {
     const ir = iw / ih;
     const r = w / h;
     let dw = w,
-        dh = h,
+        dh,
         dx = x,
         dy = y;
     if (ir > r) {


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/361](https://github.com/naruyaizumi/liora/security/code-scanning/361)

To fix this, simply remove the unnecessary initial assignment of `dh = h` on line 43. Declare the variable `dh` (as `let dh;`) but do not assign it. The value of `dh` will always be set deterministically in either branch of the conditional. This change will have no effect on the behavior of the function, but will make the code cleaner and free from the reported warning.

Specifically, in `lib/canvas.js`, on line 43, change from `dh = h,` to just `dh,`. Make sure to keep the structure of the declarations and initializations otherwise unaltered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
