### PR TITLE
Potential fix for code scanning alert no. 395: Useless assignment to local variable

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -39,7 +39,7 @@ function drawImageCover(ctx, img, x, y, w, h) {
     const ih = img.height;
     const ir = iw / ih;
     const r = w / h;
-    let dw = w,
+    let dw,
         dh,
         dx = x,
         dy = y;


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/395](https://github.com/naruyaizumi/liora/security/code-scanning/395)

To fix the problem, simply remove the initial assignment of `dw = w` on line 42 in the code. Since `dw` is always overwritten before use in all branches of the control flow, its initialization is unnecessary. The fix is to declare `dw` without initializing it. This means changing `let dw = w, dh, dx = x, dy = y;` to `let dw, dh, dx = x, dy = y;`. No imports, methods, or other code changes are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
