### PR TITLE
Potential fix for code scanning alert no. 403: Missing regular expression anchor

### DIFF
--- a/plugins/owner/owner-sf.js
+++ b/plugins/owner/owner-sf.js
@@ -27,7 +27,7 @@ const handler = async (m, { args }) => {
         }
         const q = m.quoted;
         const mime = q.mimetype || q.mediaType || "";
-        if (!q?.download || !/^image|video|audio|application/.test(mime))
+        if (!q?.download || !/^(image|video|audio|application)/.test(mime))
             return m.reply("Quoted message must be a media or document file.");
         const buffer = await q.download().catch(() => null);
         if (!buffer?.length) return m.reply("Failed to download the quoted media.");


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/403](https://github.com/naruyaizumi/liora/security/code-scanning/403)

To resolve this issue, we need to ensure that all alternatives in the regular expression are anchored to the beginning of the string; i.e., the intent is to only match if `mime` starts with "image", "video", "audio", or "application". This means rewriting the regular expression so the beginning anchor (`^`) applies to all branches. The best way is: `/^(image|video|audio|application)/`. This change should be made on line 30 of `plugins/owner/owner-sf.js`. No extra imports or definitions are required. Functionality will remain unchanged, except security and correctness of the check will improve.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
