### PR TITLE
Potential fix for code scanning alert no. 431: Comparison between inconvertible types

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -404,7 +404,7 @@ export function SQLiteKeyStore(dbPath = DEFAULT_DB, options = {}) {
         try {
             const serialized = stringify(obj);
             const result = parse(serialized);
-            if (result === null && obj !== null) {
+            if (result === null) {
                 throw new Error("Clone produced null from non-null input");
             }
             return result;


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/431](https://github.com/naruyaizumi/liora/security/code-scanning/431)

To fix this issue, simply remove the `&& obj !== null` part from the condition on line 407. The check for `obj !== null` is redundant because of the early return when `obj` is `null` or `undefined`. This can be achieved by replacing:

```js
if (result === null && obj !== null) {
```

with:

```js
if (result === null) {
```

No changes to imports, methods, or additional definitions are needed. The fix is local to the `deepClone` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
