### PR TITLE
Potential fix for code scanning alert no. 663: Missing regular expression anchor

### DIFF
--- a/src/lib/downloader.js
+++ b/src/lib/downloader.js
@@ -9,7 +9,7 @@ const TT = /(?<!\S)https?:\/\/(www\.)?(vm\.|vt\.|m\.)?tiktok\.com\/[^\s]+(?=\s|$
 const IG = /https?:\/\/(www\.)?instagram\.com\/[^\s]+/gi;
 const MF = /(?<!\S)https?:\/\/(www\.)?mediafire\.com\/\S+(?=\s|$)/gi;
 const PIN = /https?:\/\/(www\.)?(pinterest\.(com|fr|de|co\.uk|jp|ru|ca|it|com\.au|com\.mx|com\.br|es|pl)|pin\.it)\/[^\s]+/gi;
-const FB = /https?:\/\/(www\.|m\.|web\.)?facebook\.com\/[^\s]+/gi;
+const FB = /(?<!\S)https?:\/\/(www\.|m\.|web\.)?facebook\.com\/[^\s]+(?=\s|$)/gi;
 const TW = /https?:\/\/(www\.)?(twitter\.com|x\.com)\/[^\s]+/gi;
 const VD = /https?:\/\/(www\.)?videy\.co\/[^\s]+/gi;
 const TH = /https?:\/\/(www\.)?threads\.(net|com)\/[^\s]+/gi;


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/663](https://github.com/naruyaizumi/liora/security/code-scanning/663)

In general, to fix “missing regular expression anchor” issues, you either (a) add `^`/`$` if you are validating the entire input, or (b) constrain the match to URL token boundaries using lookarounds (e.g., ensuring it starts at the beginning of the string or after whitespace, and ends before whitespace or end-of-string). Since `ext` needs to find URLs *inside* free-form text, it should use the second approach, as is already done for some patterns like `TT` and `MF`.

The best fix here is to wrap the `FB` regex with the same style of lookarounds used for TikTok and MediaFire: `(?<!\S)` at the start and `(?=\s|$)` at the end. This ensures the match begins at a word/whitespace boundary (i.e., not in the middle of another token) and ends before whitespace or the end of the string, while still allowing URLs to appear anywhere in the text. Functionality will remain unchanged for normal inputs like “here is the link https://facebook.com/...”, but it will avoid matching a facebook URL that appears in the middle of an unbroken token such as `https://evil.com/?x=https://facebook.com/...` (in that case the match would start at the inner `https://facebook.com`, which is still an entire URL-like token, and is acceptable as an extracted URL).

Concretely, in `src/lib/downloader.js`, on line 12, change:

- `const FB = /https?:\/\/(www\.|m\.|web\.)?facebook\.com\/[^\s]+/gi;`

to:

- `const FB = /(?<!\S)https?:\/\/(www\.|m\.|web\.)?facebook\.com\/[^\s]+(?=\s|$)/gi;`

No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
