### PR TITLE
Potential fix for code scanning alert no. 664: Missing regular expression anchor

### DIFF
--- a/src/lib/downloader.js
+++ b/src/lib/downloader.js
@@ -10,7 +10,7 @@ const IG = /https?:\/\/(www\.)?instagram\.com\/[^\s]+/gi;
 const MF = /(?<!\S)https?:\/\/(www\.)?mediafire\.com\/\S+(?=\s|$)/gi;
 const PIN = /https?:\/\/(www\.)?(pinterest\.(com|fr|de|co\.uk|jp|ru|ca|it|com\.au|com\.mx|com\.br|es|pl)|pin\.it)\/[^\s]+/gi;
 const FB = /(?<!\S)https?:\/\/(www\.|m\.|web\.)?facebook\.com\/[^\s]+(?=\s|$)/gi;
-const TW = /https?:\/\/(www\.)?(twitter\.com|x\.com)\/[^\s]+/gi;
+const TW = /(?<!\S)https?:\/\/(www\.)?(twitter\.com|x\.com)\/[^\s]+(?=\s|$)/gi;
 const VD = /https?:\/\/(www\.)?videy\.co\/[^\s]+/gi;
 const TH = /https?:\/\/(www\.)?threads\.(net|com)\/[^\s]+/gi;
 const MG = /https?:\/\/mega\.nz\/[^\s]+/gi;


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/664](https://github.com/naruyaizumi/liora/security/code-scanning/664)

In general, to fix “missing anchor” issues for URL regexes used on untrusted text, constrain matches so they occur only at expected boundaries. For this code, the intent is to match complete Twitter/X URLs that appear as separate tokens in text, not arbitrary substrings inside other hosts or parameters. A good way to do that—consistent with the existing `TT`, `MF`, and `FB` patterns—is to require that the URL be preceded by either the start of the string or whitespace, and followed by either whitespace or the end of the string. This is already done with `(?<!\S)` (no non‑whitespace before) and `(?=\s|$)` (whitespace or end after).

The single best fix is therefore to add these boundary conditions to the `TW` regex, without changing how the rest of the code works. Specifically, change line 13 in `src/lib/downloader.js` from:

```js
const TW = /https?:\/\/(www\.)?(twitter\.com|x\.com)\/[^\s]+/gi;
```

to:

```js
const TW = /(?<!\S)https?:\/\/(www\.)?(twitter\.com|x\.com)\/[^\s]+(?=\s|$)/gi;
```

This mirrors the TikTok (`TT`) and Facebook (`FB`) patterns and ensures that when `txt.match(TW)` is called, it only extracts Twitter/X URLs that are proper tokens within the input text. No additional imports or helper methods are required; we only modify the regex literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
