### PR TITLE
Potential fix for code scanning alert no. 666: Missing regular expression anchor

### DIFF
--- a/src/lib/downloader.js
+++ b/src/lib/downloader.js
@@ -14,7 +14,7 @@ const TW = /(?<!\S)https?:\/\/(www\.)?(twitter\.com|x\.com)\/[^\s]+(?=\s|$)/gi;
 const VD = /https?:\/\/(www\.)?videy\.co\/[^\s]+/gi;
 const TH = /https?:\/\/(www\.)?threads\.(net|com)\/[^\s]+/gi;
 const MG = /https?:\/\/mega\.nz\/[^\s]+/gi;
-const SC = /https?:\/\/(www\.|on\.)?soundcloud\.com\/[^\s]+/gi;
+const SC = /(?<!\S)https?:\/\/(www\.|on\.)?soundcloud\.com\/[^\s]+(?=\s|$)/gi;
 const SP = /https?:\/\/open\.spotify\.com\/[^\s]+/gi;
 const YT = /https?:\/\/(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)[^\s]+/gi;
 const SF = /https?:\/\/sfile\.co\/[^\s]+/gi;


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/666](https://github.com/naruyaizumi/liora/security/code-scanning/666)

In general, to fix missing-anchored URL regexes used for validation or extraction, you constrain the match to a logical boundary: either the whole string (`^...$`) or at least a URL “token” delimited by whitespace or start/end of string. This prevents the regex from matching inside other, potentially malicious URLs or arbitrary text fragments.

For this codebase, other patterns (TT, MF, FB, TW) already use `(?<!\S)` at the start and `(?=\s|$)` at the end, which ensures the URL begins at a whitespace/start boundary and ends before whitespace or end of string while still allowing trailing punctuation to be stripped by `clean()`. The most consistent and minimally invasive fix is to update the SoundCloud regex `SC` to use the same pattern of lookarounds. Concretely, in `src/lib/downloader.js` line 17, change:

```js
const SC = /https?:\/\/(www\.|on\.)?soundcloud\.com\/[^\s]+/gi;
```

to:

```js
const SC = /(?<!\S)https?:\/\/(www\.|on\.)?soundcloud\.com\/[^\s]+(?=\s|$)/gi;
```

This keeps the functional intent (match `soundcloud.com` URLs with optional `www.` or `on.` prefixes and a non-whitespace path) but prevents matching when the sequence appears in the middle of another token, such as within another URL’s query string. No additional imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
