### PR TITLE
Potential fix for code scanning alert no. 672: Useless conditional

### DIFF
--- a/src/lib/core/auth/core.js
+++ b/src/lib/core/auth/core.js
@@ -249,13 +249,11 @@ class AuthDatabase {
             try {
                 const cutoffTime = Math.floor(Date.now() / 1000) - this.vacuumMaxAge;
                 let totalDeleted = 0;
-                let hasMore = true;
 
-                while (hasMore) {
+                while (true) {
                     const oldKeys = this.stmtGetOldKeys.all(cutoffTime, this.vacuumBatchSize);
 
                     if (oldKeys.length === 0) {
-                        hasMore = false;
                         break;
                     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/naruyaizumi/liora/security/code-scanning/672](https://github.com/naruyaizumi/liora/security/code-scanning/672)

In general, to fix a useless conditional where a loop-control variable is initialized to a constant and never affects the loop exit via the condition, you should remove the variable and either rewrite the loop as an infinite loop with appropriate `break` statements, or move the real termination condition into the loop predicate. The goal is to keep the logic identical while eliminating redundant state.

For this specific case in `src/lib/core/auth/core.js`, the loop uses `hasMore` as a flag but also immediately uses `break` when there are no `oldKeys`. Since `hasMore` is initialized to `true`, only set to `false` right before a `break`, and never modified elsewhere, `while (hasMore)` is equivalent to `while (true)`, and the assignment to `hasMore = false` is dead code. The minimal, behavior-preserving fix is:

- Remove the declaration `let hasMore = true;`.
- Change `while (hasMore)` to `while (true)`.
- Remove the line `hasMore = false;` inside the `if (oldKeys.length === 0)` block, because the following `break` is what actually exits the loop.

All changes are localized to the `_performVacuum` method in `src/lib/core/auth/core.js`. No imports, new methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
